### PR TITLE
Handling when the timestamp format is different

### DIFF
--- a/READ/PDF/carpe_pdf.py
+++ b/READ/PDF/carpe_pdf.py
@@ -146,7 +146,11 @@ class PDF:
             :return: (str) timestamp // UTC+0
             """
             raw_ts = ts.decode('ascii')[2:]
-            raw_ts = raw_ts.replace("'","")
+            if "'" in raw_ts:
+                raw_ts = raw_ts.replace("'", "")
+            elif "Z" in raw_ts:
+                raw_ts = raw_ts.replace("Z", "")
+                raw_ts += '+0000'
             dt = datetime.strptime(raw_ts, "%Y%m%d%H%M%S%z")
             utc_dt= dt.astimezone(timezone.utc)
 


### PR DESCRIPTION
1. PDF 생성 프로그램에 따라 메타데이터에 타임스탬프의 포맷이 다른 경우가 존재, 이에 대한 처리 구현